### PR TITLE
Add settings for ignore folder path

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -240,7 +240,7 @@ class RepeatPluginSettingTab extends PluginSettingTab {
 
     new Setting(containerEl)
         .setName('Ignore folder path')
-        .setDesc('Files in this folder will be ignored. Useful for templates.')
+        .setDesc('Notes in this folder and its subfolders will not become due. Useful for templates.')
         .addText((component) => component
           .setValue(this.plugin.settings.ignoreFolderPath)
           .onChange(async (value) => {

--- a/src/repeat/obsidian/RepeatView.tsx
+++ b/src/repeat/obsidian/RepeatView.tsx
@@ -16,12 +16,13 @@ class RepeatView extends ItemView {
   currentDueFilePath: string | undefined;
   dv: DataviewApi | undefined;
   icon = 'clock';
+  ignoreFolderPath: string;
   indexPromise: Promise<null> | undefined;
   messageContainer: HTMLElement;
   previewContainer: HTMLElement;
   root: Element;
 
-  constructor(leaf: WorkspaceLeaf) {
+  constructor(leaf: WorkspaceLeaf, ignoreFolderPath: string) {
     super(leaf);
     this.addRepeatButton = this.addRepeatButton.bind(this);
     this.disableExternalHandlers = this.disableExternalHandlers.bind(this);
@@ -38,6 +39,7 @@ class RepeatView extends ItemView {
     this.component = new Component();
 
     this.dv = getAPI(this.app);
+    this.ignoreFolderPath = ignoreFolderPath;
 
     this.root = this.containerEl.children[1];
     this.indexPromise = new Promise((resolve, reject) => {
@@ -141,7 +143,7 @@ class RepeatView extends ItemView {
     // Reset the message container so that loading message is hidden.
     this.setMessage('');
     this.messageContainer.style.display = 'none';
-    const page = getNextDueNote(this.dv);
+    const page = getNextDueNote(this.dv, this.ignoreFolderPath);
     if (!page) {
       this.setMessage('All done for now!');
       this.buttonsContainer.createEl('button', {

--- a/src/repeat/queries.ts
+++ b/src/repeat/queries.ts
@@ -23,7 +23,10 @@ export function getNotesDue(
     })
     .where((page: any) => {
       const { repetition } = page;
-      if (!repetition || page.file.folder === ignoreFolderPath) {
+      if (!repetition) {
+        return false;
+      }
+      if (page.file.folder.startsWith(ignoreFolderPath)) {
         return false;
       }
       return repetition.repeatDueAt <= now;

--- a/src/repeat/queries.ts
+++ b/src/repeat/queries.ts
@@ -5,6 +5,7 @@ import { parseRepetitionFields } from './parsers';
 
 export function getNotesDue(
   dv: DataviewApi | undefined,
+  ignoreFolderPath: string,
 ): DataArray<Record<string, Literal>> | undefined {
   const now = DateTime.now();
   return dv?.pages()
@@ -22,7 +23,7 @@ export function getNotesDue(
     })
     .where((page: any) => {
       const { repetition } = page;
-      if (!repetition) {
+      if (!repetition || page.file.folder === ignoreFolderPath) {
         return false;
       }
       return repetition.repeatDueAt <= now;
@@ -34,8 +35,9 @@ export function getNotesDue(
 
 export function getNextDueNote(
   dv: DataviewApi | undefined,
+  ignoreFolderPath: string,
 ): Record<string, Literal> | undefined {
-  const page = getNotesDue(dv)?.first();
+  const page = getNotesDue(dv, ignoreFolderPath)?.first();
   if (!page) { return; }
   return page;
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -7,5 +7,5 @@ export interface RepeatPluginSettings {
 export const DEFAULT_SETTINGS: RepeatPluginSettings = {
   showDueCountInStatusBar: true,
   showRibbonIcon: true,
-  ignoreFolderPath: "",
+  ignoreFolderPath: '',
 };

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,9 +1,11 @@
 export interface RepeatPluginSettings {
   showDueCountInStatusBar: boolean;
   showRibbonIcon: boolean;
+  ignoreFolderPath: string;
 }
 
 export const DEFAULT_SETTINGS: RepeatPluginSettings = {
   showDueCountInStatusBar: true,
   showRibbonIcon: true,
+  ignoreFolderPath: "",
 };


### PR DESCRIPTION
This PR adds a setting for a folder path to be ignored, which is useful for templates (e.g. adding `repeat` frontmatter to a template, without the template appearing in the review window).

I'm not sure if there's a better way to access the `ignoreFolderPath` settings, besides passing it to the constructor.

I've also fixed a small bug where changing the settings would cause multiple ribbon icons and status bar items to be created:

![Peek 2022-12-26 12-57](https://user-images.githubusercontent.com/2070423/209503216-8e4d7a14-0430-4eb8-8bb5-f23e3df4476a.gif)
