### PR TITLE
Only update files on metadata change after the index is loaded

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -87,14 +87,16 @@ export default class RepeatPlugin extends Plugin {
       this.app.metadataCache.on(
         // @ts-ignore: event is added by DataView.
         'dataview:index-ready',
-        this.updateNotesDueCount)
-    );
-    // Update due note count whenever metadata changes.
-    this.registerEvent(
-      this.app.metadataCache.on(
-        // @ts-ignore: event is added by DataView.
-        'dataview:metadata-change',
-        this.updateNotesDueCount)
+        () => {
+          this.updateNotesDueCount();
+          // Update due note count whenever metadata changes.
+          this.registerEvent(
+            this.app.metadataCache.on(
+              // @ts-ignore: event is added by DataView.
+              'dataview:metadata-change',
+              this.updateNotesDueCount)
+          );
+        })
     );
     // Periodically update due note count as notes become due.
     const FIVE_MINUTES_IN_MS = 5 * 60 * 1000;


### PR DESCRIPTION
The initial vault load can generate a metadata update event for each note, which causes unnecessary updates and a large delay on large vaults.

Fixes #6