### PR TITLE
Debounce due note count and live updates

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import {
   App,
+  debounce,
   MarkdownView,
   Plugin,
   PluginManifest,
@@ -18,6 +19,8 @@ import { serializeRepetition } from './repeat/serializers';
 import { incrementRepeatDueAt } from './repeat/choices';
 import { PeriodUnit, Repetition, Strategy, TimeOfDay } from './repeat/repeatTypes';
 
+const COUNT_DEBOUNCE_MS = 2 * 1000;
+
 export default class RepeatPlugin extends Plugin {
   settings: RepeatPluginSettings;
   statusBarItem: HTMLElement | undefined;
@@ -25,7 +28,8 @@ export default class RepeatPlugin extends Plugin {
 
   constructor(app: App, manifest: PluginManifest) {
     super(app, manifest);
-    this.updateNotesDueCount = this.updateNotesDueCount.bind(this);
+    this.updateNotesDueCount = debounce(
+      this.updateNotesDueCount, COUNT_DEBOUNCE_MS).bind(this);
     this.manageStatusBarItem = this.manageStatusBarItem.bind(this);
     this.registerCommands = this.registerCommands.bind(this);
     this.makeRepeatRibbonIcon = this.makeRepeatRibbonIcon.bind(this);

--- a/src/main.ts
+++ b/src/main.ts
@@ -94,12 +94,15 @@ export default class RepeatPlugin extends Plugin {
         () => {
           this.updateNotesDueCount();
           // Update due note count whenever metadata changes.
-          this.registerEvent(
-            this.app.metadataCache.on(
-              // @ts-ignore: event is added by DataView.
-              'dataview:metadata-change',
-              this.updateNotesDueCount)
-          );
+          setTimeout(() => {
+            this.registerEvent(
+              this.app.metadataCache.on(
+                // @ts-ignore: event is added by DataView.
+                'dataview:metadata-change',
+                this.updateNotesDueCount
+              )
+            );
+          }, COUNT_DEBOUNCE_MS);
         })
     );
     // Periodically update due note count as notes become due.

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,7 @@ import { serializeRepetition } from './repeat/serializers';
 import { incrementRepeatDueAt } from './repeat/choices';
 import { PeriodUnit, Repetition, Strategy, TimeOfDay } from './repeat/repeatTypes';
 
-const COUNT_DEBOUNCE_MS = 2 * 1000;
+const COUNT_DEBOUNCE_MS = 5 * 1000;
 
 export default class RepeatPlugin extends Plugin {
   settings: RepeatPluginSettings;

--- a/src/main.ts
+++ b/src/main.ts
@@ -72,10 +72,10 @@ export default class RepeatPlugin extends Plugin {
   }
 
   updateNotesDueCount() {
-    if (!this.statusBarItem) {
-      this.statusBarItem = this.addStatusBarItem();
-    }
     if (this.settings.showDueCountInStatusBar) {
+      if (!this.statusBarItem) {
+        this.statusBarItem = this.addStatusBarItem();
+      }
       const dueNoteCount = getNotesDue(
         getAPI(this.app), this.settings.ignoreFolderPath)?.length;
       if (dueNoteCount != undefined && this.statusBarItem) {

--- a/src/repeat/obsidian/RepeatView.tsx
+++ b/src/repeat/obsidian/RepeatView.tsx
@@ -1,4 +1,10 @@
-import { Component, ItemView, WorkspaceLeaf, TFile } from 'obsidian';
+import {
+  Component,
+  debounce,
+  ItemView,
+  WorkspaceLeaf,
+  TFile,
+} from 'obsidian';
 import { getAPI, DataviewApi } from 'obsidian-dataview';
 
 import { determineFrontmatterBounds, replaceOrInsertFields } from '../../frontmatter';
@@ -8,6 +14,7 @@ import { getNextDueNote } from '../queries';
 import { serializeRepetition } from '../serializers';
 import { renderMarkdown, renderTitleElement } from 'src/markdown';
 
+const MODIFY_DEBOUNCE_MS = 1 * 1000;
 export const REPEATING_NOTES_DUE_VIEW = 'repeating-notes-due-view';
 
 class RepeatView extends ItemView {
@@ -27,9 +34,12 @@ class RepeatView extends ItemView {
     this.addRepeatButton = this.addRepeatButton.bind(this);
     this.disableExternalHandlers = this.disableExternalHandlers.bind(this);
     this.enableExternalHandlers = this.enableExternalHandlers.bind(this);
-    this.handleExternalModifyOrDelete = (
-      this.handleExternalModifyOrDelete.bind(this));
-    this.handleExternalRename = this.handleExternalRename.bind(this);
+    this.handleExternalModifyOrDelete = debounce(
+      this.handleExternalModifyOrDelete,
+      MODIFY_DEBOUNCE_MS).bind(this);
+    this.handleExternalRename = debounce(
+      this.handleExternalRename,
+      MODIFY_DEBOUNCE_MS).bind(this);
     this.promiseMetadataChangeOrTimeOut = (
       this.promiseMetadataChangeOrTimeOut.bind(this));
     this.setMessage = this.setMessage.bind(this);


### PR DESCRIPTION
It looks like #6 wasn't completely solved, but this seems to do it. 

It takes a non-trivial amount of time to determine which notes are due. This op is repeatedly run on saves, which is almost all the time because Obsidian saves continuously. So we're debouncing the calls that re-calculate due note counts for the status bar with 5s period. 

Additionally, we don't start listening for note update events for 5s because one gets generated per note, even after the index is loaded (that's why #6 wasn't fixed).

Finally, we de bounce updating the currently open note. That is the note will still get updated if there were out-of-plugin changes, but the update will sometimes be delayed by a second.