### PR TITLE
Allow setting the morning and evening review times in settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "esbuild": "0.14.47",
     "eslint": "^8.24.0",
     "jest": "^29.0.3",
-    "obsidian": "^0.16.3",
+    "obsidian": "^1.4.11",
     "obsidian-dataview": "^0.5.46",
     "ts-jest": "^29.0.1",
     "tslib": "2.4.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -257,5 +257,35 @@ class RepeatPluginSettingTab extends PluginSettingTab {
             this.plugin.settings.ignoreFolderPath = value;
             await this.plugin.saveSettings();
           }));
+
+    new Setting(containerEl)
+        .setName('Morning review time')
+        .setDesc('When morning and long-term notes become due in the morning.')
+        .addText((component) => {
+          component.inputEl.type = 'time';
+          component.inputEl.addClass('repeat-date_picker');
+          component.setValue(this.plugin.settings.morningReviewTime);
+          component.onChange(async (value) => {
+            const usedValue = value >= '12:00' ? '11:59' : value;
+            this.plugin.settings.morningReviewTime = usedValue;
+            component.setValue(usedValue);
+            await this.plugin.saveSettings();
+          });
+        });
+
+      new Setting(containerEl)
+        .setName('Evening review time')
+        .setDesc('When evening notes become due in the afternoon.')
+        .addText((component) => {
+          component.inputEl.type = 'time';
+          component.inputEl.addClass('repeat-date_picker');
+          component.setValue(this.plugin.settings.eveningReviewTime);
+          component.onChange(async (value) => {
+            const usedValue = value < '12:00' ? '12:00' : value;
+            this.plugin.settings.eveningReviewTime = usedValue;
+            component.setValue(usedValue);
+            await this.plugin.saveSettings();
+          });
+        });
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -209,7 +209,7 @@ export default class RepeatPlugin extends Plugin {
     this.registerCommands();
     this.registerView(
       REPEATING_NOTES_DUE_VIEW,
-      (leaf) => new RepeatView(leaf, this.settings.ignoreFolderPath, this.settings),
+      (leaf) => new RepeatView(leaf, this.settings),
       );
     this.addSettingTab(new RepeatPluginSettingTab(this.app, this));
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -186,7 +186,7 @@ export default class RepeatPlugin extends Plugin {
               const repeatDueAt = incrementRepeatDueAt({
                 ...repeat,
                 repeatDueAt: undefined,
-              } as any);
+              } as any, this.settings);
               const newContent = updateRepetitionMetadata(content, serializeRepetition({
                 ...repeat,
                 hidden: parseHiddenFieldFromMarkdown(content),
@@ -209,7 +209,7 @@ export default class RepeatPlugin extends Plugin {
     this.registerCommands();
     this.registerView(
       REPEATING_NOTES_DUE_VIEW,
-      (leaf) => new RepeatView(leaf, this.settings.ignoreFolderPath),
+      (leaf) => new RepeatView(leaf, this.settings.ignoreFolderPath, this.settings),
       );
     this.addSettingTab(new RepeatPluginSettingTab(this.app, this));
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -146,7 +146,12 @@ export default class RepeatPlugin extends Plugin {
               const content = editor.getValue();
               repetition = parseRepetitionFromMarkdown(content);
             }
-            new RepeatNoteSetupModal(this.app, onSubmit, repetition).open();
+            new RepeatNoteSetupModal(
+              this.app,
+              onSubmit,
+              this.settings,
+              repetition,
+            ).open();
           }
           return true;
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -255,7 +255,7 @@ class RepeatPluginSettingTab extends PluginSettingTab {
 
     new Setting(containerEl)
         .setName('Ignore folder path')
-        .setDesc('Notes in this folder and its subfolders will not become due. Useful for templates.')
+        .setDesc('Notes in this folder and its subfolders will not become due. Useful to avoid reviewing templates.')
         .addText((component) => component
           .setValue(this.plugin.settings.ignoreFolderPath)
           .onChange(async (value) => {

--- a/src/repeat/choices.ts
+++ b/src/repeat/choices.ts
@@ -102,6 +102,7 @@ function getPeriodicRepeatChoices(
  * Gets all repeat button choices for a spaced note.
  * @param repetition The note's parsed repetition status.
  * @param now A reference time (for consistent diffs).
+ * @param settings Plugin settings.
  * @returns Collection of repeat choices.
  */
 function getSpacedRepeatChoices(

--- a/src/repeat/obsidian/RepeatNoteSetupModal.ts
+++ b/src/repeat/obsidian/RepeatNoteSetupModal.ts
@@ -1,8 +1,9 @@
 import { DateTime } from 'luxon';
 import { App, Modal, Setting } from 'obsidian';
-import { AM_REVIEW_TIME, incrementRepeatDueAt, PM_REVIEW_TIME } from '../choices';
+import { incrementRepeatDueAt } from '../choices';
 import { Repetition } from '../repeatTypes';
 import { summarizeDueAtWithPrefix } from '../utils';
+import { RepeatPluginSettings } from 'src/settings';
 
 const formatDateTimeForPicker = (dt: DateTime) => (
   [
@@ -17,15 +18,18 @@ class RepeatNoteSetupModal extends Modal {
   datetimePickerEl: HTMLInputElement | undefined;
   dueAtSummaryEl: HTMLElement | undefined;
   onSubmit: (result: any) => void;
+  settings: RepeatPluginSettings;
 
   constructor(
     app: App,
     onSubmit: (result: any) => void,
+    settings: RepeatPluginSettings,
     initialValue?: Repetition,
   ) {
     super(app);
     this.onSubmit = onSubmit;
-    this.updateResult = this.updateResult.bind(this)
+    this.updateResult = this.updateResult.bind(this);
+    this.settings = settings;
 
     this.result = initialValue ? { ...initialValue } : {
       repeatStrategy: 'SPACED',
@@ -115,8 +119,10 @@ class RepeatNoteSetupModal extends Modal {
 
     const timeOfDayEl = new Setting(contentEl)
       .addDropdown((dropdown) => {
-        dropdown.addOption('AM', `at ${AM_REVIEW_TIME} AM in the morning`);
-        dropdown.addOption('PM', `at ${PM_REVIEW_TIME % 12} PM in the evening`);
+        // TODO: Parse review times and use AM/PM.
+        // TODO: Only show this if the repetition period is long enough.
+        dropdown.addOption('AM', `in the morning at ${this.settings.morningReviewTime}`);
+        dropdown.addOption('PM', `in the evening at ${this.settings.eveningReviewTime}`);
         dropdown.setValue(this.result.repeatTimeOfDay);
         dropdown.onChange((value) =>	{
           this.updateResult('repeatTimeOfDay', value);

--- a/src/repeat/obsidian/RepeatNoteSetupModal.ts
+++ b/src/repeat/obsidian/RepeatNoteSetupModal.ts
@@ -3,7 +3,7 @@ import { App, Modal, Setting } from 'obsidian';
 import { incrementRepeatDueAt } from '../choices';
 import { Repetition } from '../repeatTypes';
 import { summarizeDueAtWithPrefix } from '../utils';
-import { RepeatPluginSettings } from 'src/settings';
+import { RepeatPluginSettings } from '../../settings';
 
 const formatDateTimeForPicker = (dt: DateTime) => (
   [
@@ -55,7 +55,7 @@ class RepeatNoteSetupModal extends Modal {
       ...this.result,
       // Always recompute relative to now.
       repeatDueAt: undefined,
-    });
+    }, this.settings);
     this.result.summary = summarizeDueAtWithPrefix(this.result.repeatDueAt);
     // Ensure UI consistency.
     if (this.datetimePickerEl) {

--- a/src/repeat/obsidian/RepeatView.tsx
+++ b/src/repeat/obsidian/RepeatView.tsx
@@ -186,7 +186,7 @@ class RepeatView extends ItemView {
     // Render the repeat control buttons.
     choices.forEach(choice => this.addRepeatButton(choice, file));
 
-    // .markdown-embed adds borders that shouldn't be while loading,
+    // .markdown-embed adds undesirable borders while loading,
     // so we only add the class when the note is about to be rendered.
     this.previewContainer.addClass('markdown-embed');
 

--- a/src/repeat/obsidian/RepeatView.tsx
+++ b/src/repeat/obsidian/RepeatView.tsx
@@ -24,14 +24,13 @@ class RepeatView extends ItemView {
   currentDueFilePath: string | undefined;
   dv: DataviewApi | undefined;
   icon = 'clock';
-  ignoreFolderPath: string;
   indexPromise: Promise<null> | undefined;
   messageContainer: HTMLElement;
   previewContainer: HTMLElement;
   root: Element;
   settings: RepeatPluginSettings;
 
-  constructor(leaf: WorkspaceLeaf, ignoreFolderPath: string, settings: RepeatPluginSettings) {
+  constructor(leaf: WorkspaceLeaf, settings: RepeatPluginSettings) {
     super(leaf);
     this.addRepeatButton = this.addRepeatButton.bind(this);
     this.disableExternalHandlers = this.disableExternalHandlers.bind(this);
@@ -52,7 +51,6 @@ class RepeatView extends ItemView {
 
     this.dv = getAPI(this.app);
     this.settings = settings;
-    this.ignoreFolderPath = ignoreFolderPath;
 
     this.root = this.containerEl.children[1];
     this.indexPromise = new Promise((resolve, reject) => {
@@ -156,7 +154,10 @@ class RepeatView extends ItemView {
     // Reset the message container so that loading message is hidden.
     this.setMessage('');
     this.messageContainer.style.display = 'none';
-    const page = getNextDueNote(this.dv, this.ignoreFolderPath, ignoreFilePath);
+    const page = getNextDueNote(
+      this.dv,
+      this.settings.ignoreFolderPath,
+      ignoreFilePath);
     if (!page) {
       this.setMessage('All done for now!');
       this.buttonsContainer.createEl('button', {

--- a/src/repeat/obsidian/RepeatView.tsx
+++ b/src/repeat/obsidian/RepeatView.tsx
@@ -12,7 +12,8 @@ import { getRepeatChoices } from '../choices';
 import { RepeatChoice } from '../repeatTypes';
 import { getNextDueNote } from '../queries';
 import { serializeRepetition } from '../serializers';
-import { renderMarkdown, renderTitleElement } from 'src/markdown';
+import { renderMarkdown, renderTitleElement } from '../../markdown';
+import { RepeatPluginSettings } from '../../settings';
 
 const MODIFY_DEBOUNCE_MS = 1 * 1000;
 export const REPEATING_NOTES_DUE_VIEW = 'repeating-notes-due-view';
@@ -28,8 +29,9 @@ class RepeatView extends ItemView {
   messageContainer: HTMLElement;
   previewContainer: HTMLElement;
   root: Element;
+  settings: RepeatPluginSettings;
 
-  constructor(leaf: WorkspaceLeaf, ignoreFolderPath: string) {
+  constructor(leaf: WorkspaceLeaf, ignoreFolderPath: string, settings: RepeatPluginSettings) {
     super(leaf);
     this.addRepeatButton = this.addRepeatButton.bind(this);
     this.disableExternalHandlers = this.disableExternalHandlers.bind(this);
@@ -49,6 +51,7 @@ class RepeatView extends ItemView {
     this.component = new Component();
 
     this.dv = getAPI(this.app);
+    this.settings = settings;
     this.ignoreFolderPath = ignoreFolderPath;
 
     this.root = this.containerEl.children[1];
@@ -169,7 +172,7 @@ class RepeatView extends ItemView {
     }
     const dueFilePath = (page?.file as any).path;
     this.currentDueFilePath = dueFilePath;
-    const choices = getRepeatChoices(page.repetition as any);
+    const choices = getRepeatChoices(page.repetition as any, this.settings);
     const matchingMarkdowns = this.app.vault.getMarkdownFiles()
       .filter((file) => file?.path === dueFilePath);
     if (!matchingMarkdowns) {

--- a/src/repeat/parsers.ts
+++ b/src/repeat/parsers.ts
@@ -184,3 +184,11 @@ export function parseHiddenFieldFromMarkdown(
   }
   return false;
 }
+
+export function parseTime(twentyFourHourTime: string) {
+  const [hourString, minuteString] = twentyFourHourTime.split(':');
+  return {
+    hour: parseInt(hourString),
+    minute: parseInt(minuteString),
+  };
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -2,10 +2,14 @@ export interface RepeatPluginSettings {
   showDueCountInStatusBar: boolean;
   showRibbonIcon: boolean;
   ignoreFolderPath: string;
+  morningReviewTime: string;
+  eveningReviewTime: string;
 }
 
 export const DEFAULT_SETTINGS: RepeatPluginSettings = {
   showDueCountInStatusBar: true,
   showRibbonIcon: true,
   ignoreFolderPath: '',
+  morningReviewTime: '06:00',
+  eveningReviewTime: '18:00',
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -709,6 +709,13 @@
   dependencies:
     "@types/tern" "*"
 
+"@types/codemirror@5.60.8":
+  version "5.60.8"
+  resolved "https://registry.yarnpkg.com/@types/codemirror/-/codemirror-5.60.8.tgz#b647d04b470e8e1836dd84b2879988fc55c9de68"
+  integrity sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==
+  dependencies:
+    "@types/tern" "*"
+
 "@types/estree@*":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.0.tgz#5fb2e536c1ae9bf35366eed879e827fa59ca41c2"
@@ -2505,12 +2512,12 @@ obsidian-dataview@^0.5.46:
     parsimmon "^1.18.0"
     preact "^10.6.5"
 
-obsidian@^0.16.3:
-  version "0.16.3"
-  resolved "https://registry.yarnpkg.com/obsidian/-/obsidian-0.16.3.tgz#137b7e91f949517a1bc817b1d7ef9b8aefb219bc"
-  integrity sha512-hal9qk1A0GMhHSeLr2/+o3OpLmImiP+Y+sx2ewP13ds76KXsziG96n+IPFT0mSkup1zSwhEu+DeRhmbcyCCXWw==
+obsidian@^1.4.11:
+  version "1.4.11"
+  resolved "https://registry.yarnpkg.com/obsidian/-/obsidian-1.4.11.tgz#5cba594c83a74ebad58b630c610265018abdadaa"
+  integrity sha512-BCVYTvaXxElJMl6MMbDdY/CGK+aq18SdtDY/7vH8v6BxCBQ6KF4kKxL0vG9UZ0o5qh139KpUoJHNm+6O5dllKA==
   dependencies:
-    "@types/codemirror" "0.0.108"
+    "@types/codemirror" "5.60.8"
     moment "2.29.4"
 
 obsidian@obsidianmd/obsidian-api#master:


### PR DESCRIPTION
Recall that spaced notes with a period over a week and periodic notes with a period over a day become due in the morning or evening (so there's some due time rounding). This lets you choose that time. The defaults were previously 6AM and 6PM, which was too late for some people.